### PR TITLE
Load r18n-rails to ActionMailer by default

### DIFF
--- a/r18n-rails/lib/r18n-rails.rb
+++ b/r18n-rails/lib/r18n-rails.rb
@@ -33,3 +33,5 @@ R18n::Filters.on(:untranslated_html)
 ActionController::Base.helper(R18n::Rails::Helpers)
 ActionController::Base.send(:include, R18n::Rails::Controller)
 ActionController::Base.send(:before_filter, :set_r18n)
+
+ActionMailer::Base.helper(R18n::Rails::Helpers)


### PR DESCRIPTION
Включил r18-rails в ActionMailer, поскольку по умолчанию из него не доступны хелперы r18n, что не очень удобно.
