### PR TITLE
Make sure that ActiveRecord is in use when applying fix for it 

### DIFF
--- a/r18n-rails/Gemfile.lock
+++ b/r18n-rails/Gemfile.lock
@@ -116,7 +116,7 @@ DEPENDENCIES
   r18n-rails!
   r18n-rails-api!
   rails (>= 3)
-  rake (>= 0, != 0.9.0)
+  rake (!= 0.9.0, >= 0)
   rcov
   rspec (>= 2)
   rspec-rails (>= 2)

--- a/r18n-rails/lib/r18n-rails/translated.rb
+++ b/r18n-rails/lib/r18n-rails/translated.rb
@@ -21,7 +21,7 @@ module R18n
   module Translated
     module Base
       def unlocalized_methods
-        if ancestors.include? ActiveRecord::Base
+        if defined? ActiveRecord and ancestors.include? ActiveRecord::Base
           column_names + column_names.map { |i| i + '=' } + instance_methods
         else
           instance_methods


### PR DESCRIPTION
That fix from `r18n-rails/lib/r18n-rails/translated.rb` was causing an error on rails apps which have not ActiveRecord in Gemfile, this is patch for it.
