### PR TITLE
Language switcher haml didn't work, maybe obsolete?

### DIFF
--- a/sinatra-r18n/README.rdoc
+++ b/sinatra-r18n/README.rdoc
@@ -70,10 +70,10 @@ information.
    
 7. Print available translations. For example in HAML:
    
-     %ul
-       - r18n.available_locales.each do |locale|
-         %li
-           %a{ href: "/#{locale.code}/" }= locale.title
+      %ul
+         - r18n.available_locales.each do |locale|
+		      %li
+			      %a{:href => locale.code}= locale.title
 
 == Configuration
 


### PR DESCRIPTION
Language switcher haml didn't work, maybe obsolete? Now updated to something that works (in Sinatra 1.3.1 /w Ruby 1.8.7).
