### PR TITLE
Typo in Swedish locale: "october" should be "oktober"

### DIFF
--- a/r18n-core/locales/sv-se.rb
+++ b/r18n-core/locales/sv-se.rb
@@ -10,7 +10,7 @@ module R18n
         :wday_abbrs => %w{sön mån tis ons tor fre lör},
 
         :month_names => %w{januari februari mars april maj juni juli augusti
-                           september october november december},
+                           september oktober november december},
         :month_abbrs => %w{jan feb mar apr maj jun jul aug okt nov dec},
 
         :date_format => '%Y-%m-%d',


### PR DESCRIPTION
The month of October is misspelled in the Swedish translation - the correct spelling in Swedish is "oktober", not "october". This commit corrects that spelling mistake.
