### PR TITLE
Fixed params substitution for values in format '%n'

### DIFF
--- a/r18n-core/lib/r18n-core/filters.rb
+++ b/r18n-core/lib/r18n-core/filters.rb
@@ -230,13 +230,19 @@ module R18n
   end
 
   Filters.add(String, :variables) do |content, config, *params|
+    cached_params = []
     content = content.clone
-    params.each_with_index do |param, i|
-      param = config[:locale].localize(param)
-      if defined? ActiveSupport::SafeBuffer
-        param = ActiveSupport::SafeBuffer.new + param
+    content.gsub!(/\%\d/) do |key|
+      i = key[1,].to_i
+      unless cached_params.include? i - 1
+        param = config[:locale].localize(params[i - 1])
+        if defined? ActiveSupport::SafeBuffer
+          param = ActiveSupport::SafeBuffer.new + param
+        end
+
+        cached_params[i - 1] = param
       end
-      content.gsub! "%#{i+1}", param
+      cached_params[i - 1]
     end
     content
   end

--- a/r18n-core/spec/filters_spec.rb
+++ b/r18n-core/spec/filters_spec.rb
@@ -173,6 +173,10 @@ describe R18n::Filters do
     @i18n.params(-1, 2).should == 'Is −1 between −1 and 2?'
   end
 
+  it "should substitute '%2' as param but not value of second param" do
+    @i18n.params('%2 FIRST', 'SECOND').should == 'Is %2 FIRST between %2 FIRST and SECOND?'
+  end
+
   it "should format untranslated" do
     @i18n.in.not.to_s.should   == 'in.[not]'
     @i18n.in.not.to_str.should == 'in.[not]'


### PR DESCRIPTION
There was a bug in :variables filter. When passing values in format of `%n` (where `n` is number, e.g.: `%1`, `%2`, etc.), in some cases everything is messed up cause filter treats substituted values like placeholders:

Localization file:

``` yaml
some_translation: 'Param1: %1; Param2: %2 ...'
```

View:

``` rb
t.some_translation('%2 p1', 'p2')
```

Result:

``` text
Param1: p2 p1; Param2: p2 ...
```

Correct result:

``` text
Param1: %2 p1; Param2: p2 ...
```

This can happen when you pass urls with special chars to translations.
I propose my fix and small test for this case. 
