### PR TITLE
fix hungarian time format (with :human)

### DIFF
--- a/r18n-core/locales/hu.rb
+++ b/r18n-core/locales/hu.rb
@@ -14,7 +14,6 @@ module R18n
         :date_format => '%Y. %m. %d.',
         :full_format => '%B %e.',
         :year_format => '%Y. _',
-        :time_format => '%H:%M',
 
         :number_decimal => ",",
         :number_group   => " "


### PR DESCRIPTION
There space before the time was missing so human readable dates ended up without space between `x ago` string and the time. Removed the line, because the default is ok.
