### PR TITLE
Handle BigDecimal in Locale#localize

### DIFF
--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'pathname'
 require 'singleton'
+require 'bigdecimal'
 
 module R18n
   # Information about locale (language, country and other special variant
@@ -152,8 +153,8 @@ module R18n
       case obj
       when Integer
         format_integer(obj)
-      when Float
-        format_float(obj)
+      when Float, BigDecimal
+        format_float(obj.to_f)
       when Time, DateTime, Date
         return strftime(obj, format) if format.is_a? String
         return month_standalone[obj.month - 1] if :month == format

--- a/r18n-core/spec/locale_spec.rb
+++ b/r18n-core/spec/locale_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require File.expand_path('../spec_helper', __FILE__)
+require 'bigdecimal'
 
 describe R18n::Locale do
   before :all do
@@ -73,6 +74,7 @@ describe R18n::Locale do
 
   it "should format float in local traditions" do
     @en.localize(-12345.67).should == "−12,345.67"
+    @en.localize(BigDecimal.new("-12345.67")).should == "−12,345.67"
   end
 
   it "should translate month, week days and am/pm names in strftime" do


### PR DESCRIPTION
Without this, NUMERIC or DECIMAL values coming from SQL through Sequel are incorrectly formatted:

```
  1) R18n::Locale should format float in local traditions
     Failure/Error: @en.localize(BigDecimal.new("-12345.67")).should == "−12,345.67"
       expected: "−12,345.67"
            got: "−12,345.1234567E5" (using ==)
     # ./r18n-core/spec/locale_spec.rb:77
```

I ran the specs under 1.9.3 and 1.8.7. 1.8.7 has an error if I use my native timezone, but when specifying Etc/UTC, the spec are green.
