### PR TITLE
Fixes an issue when running with Sinatra under multithreaded web-server

### DIFF
--- a/sinatra-r18n/lib/sinatra/r18n.rb
+++ b/sinatra-r18n/lib/sinatra/r18n.rb
@@ -33,7 +33,7 @@ module Sinatra
       app.before do
         ::R18n.clear_cache! if self.class.development?
 
-        ::R18n.set do
+        ::R18n.thread_set do
           if settings.default_locale
             ::R18n::I18n.default = settings.default_locale
           end


### PR DESCRIPTION
Use R18n.thread_set instead of R18n.set.
Tested with Rainbows! using ThreadPool.
