### PR TITLE
Fixed pluralization for croatian and serbian

### DIFF
--- a/r18n-core/base/hr.yml
+++ b/r18n-core/base/hr.yml
@@ -22,11 +22,11 @@ human_time:
   now: 'sad'
   today: 'danas'
   minutes_ago: !!pl
-    1: 'prije %1 minute'
+    1: 'prije jedne minute'
     2: 'prije %1 minute'
     n: 'prije %1 minuta'
   hours_ago: !!pl
-    1: 'prije %1 sata'
+    1: 'prije jednog sata'
     2: 'prije %1 sata'
     n: 'prije %1 sati'
   yesterday: 'jučer'

--- a/r18n-core/locales/hr.rb
+++ b/r18n-core/locales/hr.rb
@@ -21,9 +21,9 @@ module R18n
     def pluralize(n)
       if 0 == n
         0
-      elsif 1 == n % 10 and 11 != n % 100
+      elsif n == 1
         1
-      elsif 2 <= n % 10 and 4 >= n % 10 and (10 > n % 100 or 20 <= n % 100)
+      elsif n >= 2 and n <= 4
         2
       else
         'n'

--- a/r18n-core/locales/sr-latn.rb
+++ b/r18n-core/locales/sr-latn.rb
@@ -22,9 +22,9 @@ module R18n
     def pluralize(n)
       if 0 == n
         0
-      elsif 1 == n % 10 and 11 != n % 100
+      elsif n == 1
         1
-      elsif 2 <= n % 10 and 4 >= n % 10 and (10 > n % 100 or 20 <= n % 100)
+      elsif n >= 2 and n <= 4
         2
       else
         'n'


### PR DESCRIPTION
In Croatian and Serbian, the pluralization sometimes has a special case for quantity 2, 3 and 4 so this should fix it.
Thanks!
