### PR TITLE
Replace DL with Fiddle on Win32

### DIFF
--- a/r18n-desktop/lib/r18n-desktop/win32.rb
+++ b/r18n-desktop/lib/r18n-desktop/win32.rb
@@ -17,12 +17,12 @@ You should have received a copy of the GNU Lesser General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 =end
 
-require 'dl/import'
+require 'fiddle/import'
 
 module R18n
   class I18n
     module Kernel32
-      extend DL::Importer
+      extend Fiddle::Importer
       dlload 'Kernel32'
       extern 'int GetUserDefaultLangID()'
     end


### PR DESCRIPTION
DL, which was already deprecated in ruby 2.1.x in Win32, has been removed in ruby 2.2.x. This PR is to replace DL with Fiddle.