### PR TITLE
Better sanity check for Accept-Language header

### DIFF
--- a/r18n-core/lib/r18n-core/i18n.rb
+++ b/r18n-core/lib/r18n-core/i18n.rb
@@ -149,7 +149,7 @@ module R18n
       end
       locales << @@default
       locales.each_with_index do |locale, i|
-        if locale =~ /[_-]/
+        if locale =~ /[^_-]+[_-]/
           locales.insert(i + 1, locale.match(/([^_-]+)[_-]/)[1])
         end
       end


### PR DESCRIPTION
Prevent crashes on requests with Accept-Language header with missing language code.

Real world example (it crashed on "q=0.47,-BE"):
Accept-Language: fr-FR,fr;q=0.97,fr-BE;q=0.93,en-US;q=0.9,en;q=0.87,it-IT;q=0.83,it;q=0.8,nl-NL;q=0.77,nl;q=0.73,de-DE;q=0.7,de;q=0.67,nl-BE;q=0.63,en-GB;q=0.6,de-CH;q=0.57,fr-CH;q=0.53,fr-CA;q=0.5,en-EN;q=0.47,-BE;q=0.43,ru-RU;q=0.4,ru;q=0.37,es-ES;q=0.33,es;q=0.3,en-AU;q=0.27,be-BY;q=0.23,be;q=0.2,bg-BG;q=0.17,bg;q=0.13,fr-FR;q=0.1,en-US;q=0.07