### PR TITLE
Remove Ruby 2.1 from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 bundler_args: --without development
 rvm:
-  - 2.1.10
   - 2.2
   - 2.3
   - 2.4.0


### PR DESCRIPTION
Support of Ruby 2.1 [has ended](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/).