### PR TITLE
Fix for TranslatedString to close #136

### DIFF
--- a/r18n-core/lib/r18n-core/translated_string.rb
+++ b/r18n-core/lib/r18n-core/translated_string.rb
@@ -29,11 +29,9 @@ module R18n
     # Returns a new string object containing a copy of +str+, which translated
     # for +path+ to +locale+
     def initialize(value, locale, path, filters = nil)
-      value = value.to_s if value.is_a? TranslatedString
-      super(value)
+      super(value.to_s)
       @filters = filters
       @locale  = locale
-      @value   = value
       @path    = path
     end
 
@@ -55,9 +53,9 @@ module R18n
     # Override to_s to make string html safe if `html_safe` method is defined.
     def to_s
       if respond_to? :html_safe
-        @value.html_safe
+        super.html_safe
       else
-        @value
+        String.new(super)
       end
     end
 

--- a/r18n-core/lib/r18n-core/translation.rb
+++ b/r18n-core/lib/r18n-core/translation.rb
@@ -93,7 +93,7 @@ module R18n
           when String
             c = { locale: locale, path: path }
             v = @filters.process_string(:passive, value, c, [])
-            value = TranslatedString.new(v, locale, path, @filter)
+            value = TranslatedString.new(v, locale, path, @filters)
           when Typed
             value.locale = locale
             value.path   = path

--- a/r18n-core/spec/translation_spec.rb
+++ b/r18n-core/spec/translation_spec.rb
@@ -18,6 +18,21 @@ describe R18n::Translation do
     expect(i18n.one | 'default').to eq('One')
   end
 
+  it "returns strings which can be used as normal strings" do
+    i18n = R18n::I18n.new('en', DIR)
+    expect(i18n.not.exists).not_to be_translated
+    expect(i18n.not.exists.to_s).to be_kind_of(String)
+    expect(i18n.not.exists.to_s.split.first).to be_kind_of(String)
+    expect(i18n.not.exists.to_s.split.first.to_s).to be_kind_of(String)
+
+    expect(i18n.one).to be_translated
+    expect(i18n.one.to_s).to be_kind_of(String)
+    expect(i18n.one.to_s.split.first).to be_kind_of(String)
+    expect(i18n.one.to_s.split.first.to_s).to be_kind_of(String)
+    expect(i18n.one.split.first).to be_kind_of(String)
+    expect(i18n.one.split.first.to_s).to be_kind_of(String)
+  end
+
   it "returns html escaped string" do
     klass = Class.new(R18n::TranslatedString) do
       def html_safe


### PR DESCRIPTION
The subject says it all, this is the fix for issues discussed in #136.

The solution drops the `@value` idea and uses self as the authoritative value again instead, but the trick was to use `super` instead of `self` in `#to_s` to make it all work correctly with `String.new`, ActiveRecord's `StringBuffer`, etc.

Tested against 2.1.10, 2.2.3, 2.3.4 and 2.4.1.

BTW, note that I kept the changes at the minimum, so `Untranslated#to_s` still returns `TranslatedString`, not `String`, as it always did before. I am not sure if this was intentional or not. If you want to change this, simply adding `.to_s` on the `@filter.process` result in `Untranslated#to_s` would do the trick.