### PR TITLE
Fix TranslatedString#html_safe? always returning true

### DIFF
--- a/r18n-core/lib/r18n-core/translated_string.rb
+++ b/r18n-core/lib/r18n-core/translated_string.rb
@@ -45,9 +45,9 @@ module R18n
       true
     end
 
-    # Mark translated string as html safe, because R18n has own escape system.
+    # Return true if `html_safe` method is defined, otherwise false.
     def html_safe?
-      true
+      respond_to? :html_safe
     end
 
     # Override to_s to make string html safe if `html_safe` method is defined.

--- a/r18n-core/spec/translation_spec.rb
+++ b/r18n-core/spec/translation_spec.rb
@@ -40,7 +40,7 @@ describe R18n::Translation do
     expect(i18n.boolean[false]).to eq('Boolean is false')
   end
 
-  it "returns html escaped string" do
+  it "returns html escaped string if html_safe is defined" do
     klass = Class.new(R18n::TranslatedString) do
       def html_safe
         '2'
@@ -50,6 +50,16 @@ describe R18n::Translation do
 
     expect(str).to be_html_safe
     expect(str.html_safe).to eq('2')
+  end
+
+  it "returns unescaped string if html_safe is not defined" do
+    klass = Class.new(R18n::TranslatedString) do
+      undef_method :html_safe if method_defined?(:html_safe)
+    end
+    str = klass.new('a & b', nil, nil)
+
+    expect(str).not_to be_html_safe
+    expect(str.to_s).to eq('a & b')
   end
 
   it "loads use hierarchical translations" do


### PR DESCRIPTION
Calling `to_s` will only return an html safe string if the `html_safe` method is defined, so `html_safe?` should match that behaviour. The existing implementation creates vulnerabilities in environments where `html_safe` is not defined and objects that return true for `html_safe?` are not escaped.