### PR TITLE
Remove rubygems requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 
 GEMS = %w{r18n-core r18n-desktop sinatra-r18n r18n-rails-api r18n-rails}.freeze

--- a/benchmark/benchmark.rb
+++ b/benchmark/benchmark.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'rubygems'
-
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/r18n-core/Rakefile
+++ b/r18n-core/Rakefile
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 require 'bundler/setup'
 Bundler::GemHelper.install_tasks
 

--- a/r18n-desktop/Rakefile
+++ b/r18n-desktop/Rakefile
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 require 'bundler/setup'
 Bundler::GemHelper.install_tasks
 

--- a/r18n-rails-api/Rakefile
+++ b/r18n-rails-api/Rakefile
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 require 'bundler/setup'
 Bundler::GemHelper.install_tasks
 

--- a/r18n-rails/spec/app/config/boot.rb
+++ b/r18n-rails/spec/app/config/boot.rb
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 

--- a/sinatra-r18n/Rakefile
+++ b/sinatra-r18n/Rakefile
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 require 'bundler/setup'
 Bundler::GemHelper.install_tasks
 


### PR DESCRIPTION
They aren't necessary:

http://www.rubyinside.com/why-using-require-rubygems-is-wrong-1478.html

https://github.com/rails/rails/commit/d8c194968469f3afe39412818505ac94f78e386d#diff-64230db87218c6b7c92fb9b6c4436c46

Fewer lines of code to maintain 😊