### PR TITLE
Make `date_format` of base `en` locale international

### DIFF
--- a/r18n-core/locales/en-gb.rb
+++ b/r18n-core/locales/en-gb.rb
@@ -3,6 +3,8 @@ require File.join(File.dirname(__FILE__), 'en')
 module R18n::Locales
   class EnGb < En
     set title: 'British English',
-        sublocales: %w{en}
+        sublocales: %w{en},
+
+        date_format: '%d/%m/%Y'
   end
 end

--- a/r18n-core/locales/en.rb
+++ b/r18n-core/locales/en.rb
@@ -12,7 +12,7 @@ module R18n
                         September October November December},
         month_abbrs: %w{Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec},
 
-        date_format: '%d/%m/%Y',
+        date_format: '%Y-%m-%d',
         full_format: '%e of %B',
         year_format: '_, %Y',
 


### PR DESCRIPTION
There is no warranty that base `en` will not be showed for US users with another format.

In Ruby on Rails:

* [en](https://github.com/svenfuchs/rails-i18n/blob/fe07d45/rails/locale/en.yml#L42)
* [en-US](https://github.com/svenfuchs/rails-i18n/blob/fe07d45/rails/locale/en-US.yml#L42)
* [en-GB](https://github.com/svenfuchs/rails-i18n/blob/fe07d45/rails/locale/en-GB.yml#L42)