### PR TITLE
Fix code examples in READMEs after date format changing for `en` locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ t.user.count(5)     #=> "There are 5 users"
 t.not.exists | 'default' #=> "default"
 t.not.exists.translated? #=> false
 
-l Time.now         #=> "03/01/2010 18:54"
+l Time.now         #=> "2010-01-03 18:54"
 l Time.now, :human #=> "now"
 l Time.now, :full  #=> "3rd of January, 2010 18:54"
 ```

--- a/r18n-core/README.md
+++ b/r18n-core/README.md
@@ -324,8 +324,8 @@ R18n has some built-in time formats for locales: `:human`, `:full` and
 ```ruby
 l Time.now, :human #=> "now"
 l Time.now, :full  #=> "August 9th, 2009 21:47"
-l Time.now         #=> "08/09/2009 21:41"
-l Time.now.to_date #=> "08/09/2009"
+l Time.now         #=> "2009-08-09 21:41"
+l Time.now.to_date #=> "2009-08-09"
 ```
 
 ### Model

--- a/r18n-desktop/README.md
+++ b/r18n-desktop/README.md
@@ -66,7 +66,7 @@ See full features in [main README](https://github.com/ai/r18n/blob/master/README
     t.files(12)           #=> "12 files"
 
     l -12000.5          #=> "−12,000.5"
-    l Time.now          #=> "08/09/2009 21:41"
+    l Time.now          #=> "2009-08-09 21:41"
     l Time.now, :human  #=> "now"
     l Time.now, :full   #=> "August 9th, 2009 21:41"
 

--- a/r18n-rails/README.md
+++ b/r18n-rails/README.md
@@ -85,7 +85,7 @@ See full features in [main README](https://github.com/ai/r18n/blob/master/README
 6. Print dates and numbers in user’s tradition:
 
      ```ruby
-    l Date.today, :standard #=> "20/12/2009"
+    l Date.today, :standard #=> "2009-12-20"
     l Time.now,   :full     #=> "20th of December, 2009 12:00"
     l 1234.5                #=> "1,234.5"
      ```


### PR DESCRIPTION
:grimacing: 