### PR TITLE
Fix `Locale#localize` method for `DateTime` objects

### DIFF
--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -159,7 +159,7 @@ module R18n
         return month_standalone[obj.month - 1] if :month == format
         return obj.to_s if :human == format and not params.first.is_a? I18n
 
-        type = obj.is_a?(Date) ? 'date' : 'time'
+        type = obj.is_a?(Date) && !obj.is_a?(DateTime) ? 'date' : 'time'
         format = :standard unless format
 
         unless [:human, :full, :standard].include? format
@@ -224,7 +224,8 @@ module R18n
     # “yesterday”. In +now+ you can set base time, which be used to get relative
     # time. For special cases you can replace it in locale’s class.
     def format_time_human(time, i18n, now = Time.now, *params)
-      minutes = (time - now) / 60.0
+      diff = time - now
+      minutes = time.is_a?(DateTime) ? diff * 24 * 60.0 : diff / 60.0
       diff = minutes.abs
       if (diff > 24 * 60) or (time.mday != now.mday and diff > 12 * 24)
         format_time(format_date_human(time.to_date, i18n, now.to_date), time)

--- a/r18n-core/spec/locale_spec.rb
+++ b/r18n-core/spec/locale_spec.rb
@@ -131,6 +131,34 @@ describe R18n::Locale do
       '1st of January, 1969 00:00')
   end
 
+  it "localizes date-times for human" do
+    day    = 1.0
+    hour   = day / 24
+    minute = hour / 60
+    second = minute / 60
+    zero   = DateTime.new(1970)
+    p = [:human, R18n::I18n.new('en'), zero]
+
+    expect(@en.localize( zero + 7  * day,    *p)).to eq('8th of January 00:00')
+    expect(@en.localize( zero + 50 * hour,   *p)).to eq('after 2 days 02:00')
+    expect(@en.localize( zero + 25 * hour,   *p)).to eq('tomorrow 01:00')
+    expect(@en.localize( zero + 70 * minute, *p)).to eq('after 1 hour')
+    expect(@en.localize( zero + hour,        *p)).to eq('after 1 hour')
+    expect(@en.localize( zero + 38 * minute, *p)).to eq('after 38 minutes')
+    expect(@en.localize( zero + 5 * second,  *p)).to eq('now')
+    expect(@en.localize( zero - 15 * second, *p)).to eq('now')
+    expect(@en.localize( zero - minute,      *p)).to eq('1 minute ago')
+    expect(@en.localize( zero - hour + 59 * second, *p)).to eq('59 minutes ago')
+    expect(@en.localize( zero - 2  * hour,   *p)).to eq('2 hours ago')
+    expect(@en.localize( zero - 13 * hour,   *p)).to eq('yesterday 11:00')
+    expect(@en.localize( zero - 50 * hour,   *p)).to eq('3 days ago 22:00')
+
+    expect(@en.localize( zero - 9  * day,  *p)).to eq(
+      '23rd of December, 1969 00:00')
+    expect(@en.localize( zero - 365 * day, *p)).to eq(
+      '1st of January, 1969 00:00')
+  end
+
   it "uses standard formatter by default" do
     expect(@ru.localize(Time.at(0).utc)).to eq('01.01.1970 00:00')
   end


### PR DESCRIPTION
```ruby
DateTime.now.is_a?(Date) # => true
```

But this type also has time information.