### PR TITLE
Simplify files requiring

### DIFF
--- a/benchmark/benchmark.rb
+++ b/benchmark/benchmark.rb
@@ -7,9 +7,6 @@ rescue LoadError
   puts 'Bundler not available. Install it with: gem install bundler'
 end
 
-require 'pathname'
-dir = Pathname.new(__FILE__).dirname.expand_path
-
 require 'i18n'
 require 'rbench'
 require 'r18n-core'
@@ -34,14 +31,14 @@ RBench.run(1000) do
   report 'cold load' do
     r18n do
       R18n.clear_cache!
-      R18n.set(%w[ru fr en], dir + 'r18n')
+      R18n.set(%w[ru fr en], File.join(__dir__, 'r18n'))
       R18n.get.available_locales
     end
     i18n do
       I18n.reload!
       I18n.available_locales = nil
 
-      I18n.load_path = [Dir.glob(dir.join('i18n/*.{yml,rb}').to_s)]
+      I18n.load_path = [Dir.glob(File.join(__dir__, 'i18n', '*.{yml,rb}'))]
       I18n.locale = :ru
       I18n.fallbacks[:ru] = %i[ru en]
       I18n.available_locales
@@ -50,7 +47,7 @@ RBench.run(1000) do
 
   report 'load' do
     r18n do
-      R18n.set(%w[ru fr en], dir + 'r18n')
+      R18n.set(%w[ru fr en], File.join(__dir__, 'r18n'))
       R18n.get.available_locales
     end
     i18n do

--- a/r18n-core/.rspec
+++ b/r18n-core/.rspec
@@ -1,1 +1,1 @@
---format documentation --colour
+--format documentation --colour --require spec_helper

--- a/r18n-core/lib/r18n-core.rb
+++ b/r18n-core/lib/r18n-core.rb
@@ -17,22 +17,23 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'pathname'
-
-dir = Pathname(__FILE__).dirname.expand_path + 'r18n-core'
-require dir.join('version').to_s
-require dir.join('utils').to_s
-require dir.join('locale').to_s
-require dir.join('unsupported_locale').to_s
-require dir.join('translated_string').to_s
-require dir.join('untranslated').to_s
-require dir.join('translation').to_s
-require dir.join('filters').to_s
-require dir.join('filter_list').to_s
-require dir.join('yaml_methods').to_s
-require dir.join('yaml_loader').to_s
-require dir.join('i18n').to_s
-require dir.join('helpers').to_s
+%w[
+  version
+  utils
+  locale
+  unsupported_locale
+  translated_string
+  untranslated
+  translation
+  filters
+  filter_list
+  yaml_methods
+  yaml_loader
+  i18n
+  helpers
+].each do |file|
+  require_relative File.join('r18n-core', file)
+end
 
 module R18n
   autoload :Translated, 'r18n-core/translated'
@@ -150,9 +151,8 @@ module R18n
     attr_accessor :cache
   end
 
-  dir = Pathname(__FILE__).dirname.expand_path
   self.default_loader   = R18n::Loader::YAML
   self.default_places   = nil
-  self.extension_places = [Loader::YAML.new(dir + '../base')]
+  self.extension_places = [Loader::YAML.new(File.join(__dir__, '..', 'base'))]
   clear_cache!
 end

--- a/r18n-core/lib/r18n-core/i18n.rb
+++ b/r18n-core/lib/r18n-core/i18n.rb
@@ -18,7 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'date'
-require 'pathname'
 
 module R18n
   # General class to i18n support in your application. It load Translation and

--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'pathname'
 require 'singleton'
 require 'bigdecimal'
 
@@ -55,7 +54,7 @@ module R18n
   # You can see more available data about locale in samples in
   # <tt>locales/</tt> dir.
   class Locale
-    LOCALES_DIR = Pathname(__FILE__).dirname.expand_path + '../../locales/'
+    LOCALES_DIR = File.join(__dir__, '..', '..', 'locales')
 
     @@loaded = {}
 
@@ -68,7 +67,7 @@ module R18n
 
     # Is +locale+ has info file.
     def self.exists?(locale)
-      File.exist?(File.join(LOCALES_DIR, locale.to_s + '.rb'))
+      File.exist?(File.join(LOCALES_DIR, "#{locale}.rb"))
     end
 
     # Load locale by RFC 3066 +code+.
@@ -78,7 +77,7 @@ module R18n
 
       @@loaded[code] ||= begin
         if exists? code
-          require LOCALES_DIR.join("#{code}.rb").to_s
+          require File.join(LOCALES_DIR, "#{code}.rb")
           name = code.gsub(/\w+/, &:capitalize).delete('-')
           # rubocop:disable Security/Eval
           eval('R18n::Locales::' + name).new

--- a/r18n-core/lib/r18n-core/translation.rb
+++ b/r18n-core/lib/r18n-core/translation.rb
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'pathname'
-
 module R18n
   # Struct to containt translation with some type for filter.
   Typed = Struct.new(:type, :value, :locale, :path)

--- a/r18n-core/locales/en-au.rb
+++ b/r18n-core/locales/en-au.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'en')
+require_relative 'en'
 
 module R18n
   module Locales

--- a/r18n-core/locales/en-gb.rb
+++ b/r18n-core/locales/en-gb.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'en')
+require_relative 'en'
 
 module R18n
   module Locales

--- a/r18n-core/locales/en-us.rb
+++ b/r18n-core/locales/en-us.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'en')
+require_relative 'en'
 
 module R18n
   module Locales

--- a/r18n-core/locales/es-us.rb
+++ b/r18n-core/locales/es-us.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'es')
+require_relative 'es'
 
 module R18n
   module Locales

--- a/r18n-core/locales/pt-br.rb
+++ b/r18n-core/locales/pt-br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'pt')
+require_relative 'pt'
 
 module R18n
   module Locales

--- a/r18n-core/locales/uk.rb
+++ b/r18n-core/locales/uk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'ru')
+require_relative 'ru'
 
 module R18n
   module Locales

--- a/r18n-core/locales/zh-cn.rb
+++ b/r18n-core/locales/zh-cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'zh')
+require_relative 'zh'
 
 module R18n
   module Locales

--- a/r18n-core/locales/zh-tw.rb
+++ b/r18n-core/locales/zh-tw.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), 'zh')
+require_relative 'zh'
 
 module R18n
   module Locales

--- a/r18n-core/r18n-core.gemspec
+++ b/r18n-core/r18n-core.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../lib/r18n-core/version', __FILE__)
+require_relative 'lib/r18n-core/version'
 
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY

--- a/r18n-core/spec/filters_spec.rb
+++ b/r18n-core/spec/filters_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n::Filters do
   before do
     @system  = R18n::Filters.defined.values

--- a/r18n-core/spec/i18n_spec.rb
+++ b/r18n-core/spec/i18n_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n::I18n do
   before do
     @extension_places = R18n.extension_places.clone

--- a/r18n-core/spec/locale_spec.rb
+++ b/r18n-core/spec/locale_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
 require 'bigdecimal'
 
 describe R18n::Locale do

--- a/r18n-core/spec/locales/cs_spec.rb
+++ b/r18n-core/spec/locales/cs_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Cs do
   it 'uses Czech pluralization' do
     cs = R18n.locale('cs')

--- a/r18n-core/spec/locales/en-us_spec.rb
+++ b/r18n-core/spec/locales/en-us_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::EnUs do
   it 'formats American English date' do
     en_us = R18n::I18n.new('en-US')

--- a/r18n-core/spec/locales/en_spec.rb
+++ b/r18n-core/spec/locales/en_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::En do
   it 'formats English date' do
     en = R18n::I18n.new('en')

--- a/r18n-core/spec/locales/fa_spec.rb
+++ b/r18n-core/spec/locales/fa_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Fa do
   it 'formats Persian numerals' do
     fa = R18n::I18n.new('fa')

--- a/r18n-core/spec/locales/fr_spec.rb
+++ b/r18n-core/spec/locales/fr_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Fr do
   it 'formats French date' do
     fr = R18n::I18n.new('fr')

--- a/r18n-core/spec/locales/hu_spec.rb
+++ b/r18n-core/spec/locales/hu_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Hu do
   it 'uses Hungarian digits groups' do
     hu = R18n::I18n.new('hu')

--- a/r18n-core/spec/locales/it_spec.rb
+++ b/r18n-core/spec/locales/it_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::It do
   it 'formats Italian date' do
     italian = R18n::I18n.new('it')

--- a/r18n-core/spec/locales/pl_spec.rb
+++ b/r18n-core/spec/locales/pl_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Pl do
   it 'uses Polish pluralization' do
     pl = R18n.locale('pl')

--- a/r18n-core/spec/locales/ru_spec.rb
+++ b/r18n-core/spec/locales/ru_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Ru do
   it 'uses Russian pluralization' do
     ru = R18n.locale('ru')

--- a/r18n-core/spec/locales/sk_spec.rb
+++ b/r18n-core/spec/locales/sk_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Sk do
   it 'uses Slovak pluralization' do
     sk = R18n.locale('Sk')

--- a/r18n-core/spec/locales/th_spec.rb
+++ b/r18n-core/spec/locales/th_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Th do
   it 'uses Thai calendar' do
     th = R18n::I18n.new('th')

--- a/r18n-core/spec/locales/vi_spec.rb
+++ b/r18n-core/spec/locales/vi_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 describe R18n::Locales::Vi do
   it 'change times position' do
     th = R18n::I18n.new('vi')

--- a/r18n-core/spec/r18n_spec.rb
+++ b/r18n-core/spec/r18n_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n do
   include R18n::Helpers
 

--- a/r18n-core/spec/spec_helper.rb
+++ b/r18n-core/spec/spec_helper.rb
@@ -2,15 +2,17 @@
 
 require 'pp'
 
-dir = Pathname(__FILE__).dirname
+require_relative '../lib/r18n-core'
+Dir.glob(File.join(__dir__, '..', 'locales', '*.rb')) do |locale_file|
+  require locale_file
+end
 
-require dir.join('../lib/r18n-core').to_s
-Dir.glob(dir.join('../locales/*.rb').to_s) { |locale| require locale }
-
-TRANSLATIONS = dir + 'translations' unless defined? TRANSLATIONS
-DIR = TRANSLATIONS + 'general' unless defined? DIR
-TWO = TRANSLATIONS + 'two'     unless defined? TWO
-EXT = R18n::Loader::YAML.new(TRANSLATIONS + 'extension') unless defined? EXT
+TRANSLATIONS = File.join(__dir__, 'translations') unless defined? TRANSLATIONS
+DIR = File.join(TRANSLATIONS, 'general') unless defined? DIR
+TWO = File.join(TRANSLATIONS, 'two')     unless defined? TWO
+unless defined? EXT
+  EXT = R18n::Loader::YAML.new(File.join(TRANSLATIONS, 'extension'))
+end
 
 RSpec.configure do |config|
   config.before { R18n.clear_cache! }

--- a/r18n-core/spec/translated_spec.rb
+++ b/r18n-core/spec/translated_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n::Translated do
   before do
     @user_class = Class.new do

--- a/r18n-core/spec/translation_spec.rb
+++ b/r18n-core/spec/translation_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n::Translation do
   it "returns unstranslated string if translation isn't found" do
     i18n = R18n::I18n.new('en', DIR)

--- a/r18n-core/spec/yaml_loader_spec.rb
+++ b/r18n-core/spec/yaml_loader_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n::Loader::YAML do
   before :all do
     R18n::Filters.add('my', :my) { |i| i }
@@ -16,7 +14,7 @@ describe R18n::Loader::YAML do
   end
 
   it 'returns dir with translations' do
-    expect(@loader.dir).to eq(DIR.expand_path.to_s)
+    expect(@loader.dir).to eq(DIR)
   end
 
   it 'equals to another YAML loader with same dir' do

--- a/r18n-desktop/.rspec
+++ b/r18n-desktop/.rspec
@@ -1,1 +1,1 @@
---format documentation --colour
+--format documentation --colour --require spec_helper

--- a/r18n-desktop/lib/r18n-desktop.rb
+++ b/r18n-desktop/lib/r18n-desktop.rb
@@ -19,16 +19,14 @@
 
 require 'r18n-core'
 
-require 'pathname'
-dir = Pathname(__FILE__).dirname.expand_path + 'r18n-desktop'
 if /cygwin|mingw|win32/ =~ RUBY_PLATFORM
-  require dir.join('win32').to_s
+  require_relative 'r18n-desktop/win32'
 elsif /java/ =~ RUBY_PLATFORM
-  require dir.join('java').to_s
+  require_relative 'r18n-desktop/java'
 elsif /darwin/ =~ RUBY_PLATFORM
-  require dir.join('osx').to_s
+  require_relative 'r18n-desktop/osx'
 else
-  require dir.join('posix').to_s
+  require_relative 'r18n-desktop/posix'
 end
 
 module R18n

--- a/r18n-desktop/r18n-desktop.gemspec
+++ b/r18n-desktop/r18n-desktop.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../r18n-core/lib/r18n-core/version', __FILE__)
+require_relative '../r18n-core/lib/r18n-core/version'
 
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY

--- a/r18n-desktop/spec/r18n-desktop_spec.rb
+++ b/r18n-desktop/spec/r18n-desktop_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe 'r18n-desktop' do
   include R18n::Helpers
 

--- a/r18n-desktop/spec/spec_helper.rb
+++ b/r18n-desktop/spec/spec_helper.rb
@@ -2,4 +2,4 @@
 
 require 'pp'
 
-require File.join(File.dirname(__FILE__), '../lib/r18n-desktop')
+require_relative '../lib/r18n-desktop'

--- a/r18n-rails-api/.rspec
+++ b/r18n-rails-api/.rspec
@@ -1,1 +1,1 @@
---format documentation --colour
+--format documentation --colour --require spec_helper

--- a/r18n-rails-api/lib/r18n-rails-api.rb
+++ b/r18n-rails-api/lib/r18n-rails-api.rb
@@ -17,11 +17,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'pathname'
 require 'r18n-core'
 
-dir = Pathname(__FILE__).dirname.expand_path + 'r18n-rails-api'
-require dir + 'rails_plural'
-require dir + 'filters'
-require dir + 'loader'
-require dir + 'backend'
+require_relative 'r18n-rails-api/rails_plural'
+require_relative 'r18n-rails-api/filters'
+require_relative 'r18n-rails-api/loader'
+require_relative 'r18n-rails-api/backend'

--- a/r18n-rails-api/r18n-rails-api.gemspec
+++ b/r18n-rails-api/r18n-rails-api.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../r18n-core/lib/r18n-core/version', __FILE__)
+require_relative '../r18n-core/lib/r18n-core/version'
 
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY

--- a/r18n-rails-api/spec/backend_spec.rb
+++ b/r18n-rails-api/spec/backend_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n::Backend do
   before do
     I18n.load_path = [GENERAL]

--- a/r18n-rails-api/spec/filters_spec.rb
+++ b/r18n-rails-api/spec/filters_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe 'Rails filters' do
   it 'uses named variables' do
     i18n = R18n::Translation.new(

--- a/r18n-rails-api/spec/loader_spec.rb
+++ b/r18n-rails-api/spec/loader_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe R18n::Loader::Rails do
   before do
     I18n.load_path = [SIMPLE]

--- a/r18n-rails-api/spec/spec_helper.rb
+++ b/r18n-rails-api/spec/spec_helper.rb
@@ -6,13 +6,13 @@ require 'active_support'
 
 I18n.enforce_available_locales = true
 
-require File.join(File.dirname(__FILE__), '../lib/r18n-rails-api')
+require_relative '../lib/r18n-rails-api'
 
 EN   = R18n.locale(:en)
 RU   = R18n.locale(:ru)
 DECH = R18n.locale(:'de-CH')
 
-GENERAL = Dir.glob(File.join(File.dirname(__FILE__), 'data/general/*'))
-SIMPLE  = Dir.glob(File.join(File.dirname(__FILE__), 'data/simple/*'))
-OTHER   = Dir.glob(File.join(File.dirname(__FILE__), 'data/other/*'))
-PL      = Dir.glob(File.join(File.dirname(__FILE__), 'data/pl/*'))
+GENERAL = Dir.glob(File.join(__dir__, 'data', 'general', '*'))
+SIMPLE  = Dir.glob(File.join(__dir__, 'data', 'simple', '*'))
+OTHER   = Dir.glob(File.join(__dir__, 'data', 'other', '*'))
+PL      = Dir.glob(File.join(__dir__, 'data', 'pl', '*'))

--- a/r18n-rails/.rspec
+++ b/r18n-rails/.rspec
@@ -1,1 +1,1 @@
---format documentation --colour
+--format documentation --colour --require spec_helper

--- a/r18n-rails/lib/r18n-rails.rb
+++ b/r18n-rails/lib/r18n-rails.rb
@@ -17,15 +17,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'pathname'
 require 'r18n-core'
 require 'r18n-rails-api'
 
-dir = Pathname(__FILE__).dirname.expand_path + 'r18n-rails'
-require dir + 'helpers'
-require dir + 'controller'
-require dir + 'translated'
-require dir + 'filters'
+require_relative 'r18n-rails/helpers'
+require_relative 'r18n-rails/controller'
+require_relative 'r18n-rails/translated'
+require_relative 'r18n-rails/filters'
 
 R18n.default_places { [Rails.root.join('app/i18n'), R18n::Loader::Rails.new] }
 

--- a/r18n-rails/r18n-rails.gemspec
+++ b/r18n-rails/r18n-rails.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../r18n-core/lib/r18n-core/version', __FILE__)
+require_relative '../r18n-core/lib/r18n-core/version'
 
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY

--- a/r18n-rails/spec/app/config.ru
+++ b/r18n-rails/spec/app/config.ru
@@ -2,5 +2,5 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require_relative 'config/environment'
 run App::Application

--- a/r18n-rails/spec/app/config/application.rb
+++ b/r18n-rails/spec/app/config/application.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../boot', __FILE__)
+require_relative 'boot'
 
 require 'active_record/railtie'
 require 'action_controller/railtie'

--- a/r18n-rails/spec/app/config/boot.rb
+++ b/r18n-rails/spec/app/config/boot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.join(__dir__, '..', 'Gemfile')
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/r18n-rails/spec/app/config/environment.rb
+++ b/r18n-rails/spec/app/config/environment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Load the rails application
-require File.expand_path('../application', __FILE__)
+require_relative 'application'
 
 # Initialize the rails application
 App::Application.initialize!

--- a/r18n-rails/spec/rails_spec.rb
+++ b/r18n-rails/spec/rails_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe TestController, type: :controller do
   render_views
 

--- a/r18n-rails/spec/spec_helper.rb
+++ b/r18n-rails/spec/spec_helper.rb
@@ -3,8 +3,8 @@
 require 'pp'
 
 ENV['RAILS_ENV'] ||= 'test'
-dir = File.dirname(__FILE__)
-require File.expand_path(File.join(dir, 'app/config/environment'))
-require File.expand_path(File.join(dir, '../lib/r18n-rails'))
+
+require_relative 'app/config/environment'
+require_relative '../lib/r18n-rails'
 
 require 'rspec/rails'

--- a/sinatra-r18n/.rspec
+++ b/sinatra-r18n/.rspec
@@ -1,1 +1,1 @@
---format documentation --colour
+--format documentation --colour --require spec_helper

--- a/sinatra-r18n/README.md
+++ b/sinatra-r18n/README.md
@@ -46,7 +46,7 @@ information.
      ```ruby
     class YourApp < Sinatra::Base
       register Sinatra::R18n
-      set :root, File.dirname(__FILE__)
+      set :root, __dir__
      ```
 
 4. Add locale to your URLs. For example:

--- a/sinatra-r18n/lib/sinatra/r18n.rb
+++ b/sinatra-r18n/lib/sinatra/r18n.rb
@@ -27,7 +27,7 @@ module Sinatra
       app.set :default_locale, (proc { ::R18n::I18n.default })
       app.set :translations,   (proc { ::R18n.default_places })
 
-      ::R18n.default_places { File.join(app.root, 'i18n/') }
+      ::R18n.default_places { File.join(app.root, 'i18n') }
 
       app.before do
         ::R18n.clear_cache! if self.class.development?

--- a/sinatra-r18n/sinatra-r18n.gemspec
+++ b/sinatra-r18n/sinatra-r18n.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../r18n-core/lib/r18n-core/version', __FILE__)
+require_relative '../r18n-core/lib/r18n-core/version'
 
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY

--- a/sinatra-r18n/spec/app/app.rb
+++ b/sinatra-r18n/spec/app/app.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), '../../lib/sinatra/r18n')
+require_relative '../../lib/sinatra/r18n'
 require 'sinatra'
 
 get '/:locale/posts/:name' do

--- a/sinatra-r18n/spec/sinatra-r18n_spec.rb
+++ b/sinatra-r18n/spec/sinatra-r18n_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path('../spec_helper', __FILE__)
-
 describe Sinatra::R18n do
   before(:all) do
     Sinatra::R18n.registered(app)
@@ -86,7 +84,7 @@ describe Sinatra::R18n do
   end
 
   it 'sets default places' do
-    path = Pathname(__FILE__).dirname.expand_path.join('app/i18n/').to_s
+    path = File.join(__dir__, 'app', 'i18n')
     expect(R18n.default_places).to eq path
     R18n.set('en')
     expect(R18n.get.post.title(1)).to eq 'Post 1'

--- a/sinatra-r18n/spec/spec_helper.rb
+++ b/sinatra-r18n/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'pp'
 
 ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'app/app')
+require_relative 'app/app'
 
 require 'rack/test'
 


### PR DESCRIPTION
* Use `Kernel#__dir__`
* Use `Kernel#require_relative`
* Remove using `Pathname` from Stdlib as possible
* Take out `require 'spec_helper'` to `.rspec` files

Resolve #165