### PR TITLE
Make sure Untranslated#to_s returns String as expected.

### DIFF
--- a/r18n-core/lib/r18n-core/untranslated.rb
+++ b/r18n-core/lib/r18n-core/untranslated.rb
@@ -95,7 +95,7 @@ module R18n
       @filters.process(
         :all, Untranslated, path, @locale, path,
         [@translated_path, @untranslated_path, path]
-      )
+      ).to_s
     end
 
     alias to_str to_s


### PR DESCRIPTION
As I have mentioned this issue in #147 already, it returned `TranslatedString` before. This often made code which uses localized strings work when the strings were translated but break when they were not translated. For example, something like
``` ruby
   puts "foo".gsub("x", t.some.string)
```
worked when `t.some.string` was translated but crashed when it was not, even if the localized string itself is not used as such in this case.

As we have been recently bitten by this issue again, I thought it might be a good idea to have it fixed. It goes without saying that I have made sure that all the specs still work in all the tested rubies as well. If we could eventually get a release with this included, it would be great. Thanks.