### PR TITLE
Fix bug with `Untranslated#to_s`, when it initialized without `filters`

### DIFF
--- a/r18n-core/lib/r18n-core/filter_list.rb
+++ b/r18n-core/lib/r18n-core/filter_list.rb
@@ -56,7 +56,7 @@ module R18n
       end
 
       if value.class == String
-        TranslatedString.new(value, config[:locale], config[:path])
+        TranslatedString.new(value, config[:locale], config[:path], self)
       else
         value
       end

--- a/r18n-core/spec/filters_spec.rb
+++ b/r18n-core/spec/filters_spec.rb
@@ -194,6 +194,8 @@ describe R18n::Filters do
     expect(@i18n.in.not.to_s).to   eq('in.[not]')
     expect(@i18n.in.not.to_str).to eq('in.[not]')
 
+    expect(@i18n.one.not_exists.to_s).to eq('one.[not_exists]')
+
     R18n::Filters.off(:untranslated)
     expect(@i18n.in.not.to_s).to eq('in.not')
 


### PR DESCRIPTION
... from `TranslatedString`, which initialized without `filters` from `FilterList`.

-----

It's very critical old bug. I've spend around 1 hour to find this. I'm very sad that `r18n-core` have no unit specs for `TranslatedString`, `FilterList` and `Untranslated`.