### PR TITLE
Fix `R18n.set` for `r18n-desktop`

### DIFF
--- a/r18n-desktop/lib/r18n-desktop.rb
+++ b/r18n-desktop/lib/r18n-desktop.rb
@@ -35,10 +35,11 @@ module R18n
     # information and translations from +translations_places+. If user set
     # locale +manual+ put it as last argument.
     def from_env(translations_places = nil, manual = nil)
+      ::R18n.default_places { translations_places }
       locales = Array(R18n::I18n.system_locale)
       locales.unshift(ENV['LANG']) if ENV['LANG']
       locales.unshift(manual)      if manual
-      set I18n.new(locales, translations_places)
+      set ::R18n::I18n.new(locales, translations_places)
     end
   end
 end

--- a/r18n-desktop/spec/i18n/en.yml
+++ b/r18n-desktop/spec/i18n/en.yml
@@ -1,0 +1,2 @@
+account:
+  balance: Balance for account

--- a/r18n-desktop/spec/r18n-desktop_spec.rb
+++ b/r18n-desktop/spec/r18n-desktop_spec.rb
@@ -13,23 +13,31 @@ describe 'r18n-desktop' do
     expect(locale).not_to be_empty
   end
 
-  it 'loads I18n from system environment' do
-    R18n.from_env
-    expect(r18n.class).to eq R18n::I18n
-    expect(r18n.locale).not_to be_empty if String == r18n.locale.class
-    expect(R18n.get).to eq r18n
-  end
+  describe '.from_env' do
+    it 'loads I18n from system environment' do
+      R18n.from_env
+      expect(r18n.class).to eq R18n::I18n
+      expect(r18n.locale).not_to be_empty if String == r18n.locale.class
+      expect(R18n.get).to eq r18n
+    end
 
-  it 'loads i18n from system environment using specified order' do
-    R18n.from_env(nil, 'en')
-    expect(r18n.locale).to eq R18n.locale('en')
-    expect(R18n.get).to eq r18n
-  end
+    it 'loads i18n from system environment using specified order' do
+      R18n.from_env(nil, 'en')
+      expect(r18n.locale).to eq R18n.locale('en')
+      expect(R18n.get).to eq r18n
+    end
 
-  it 'allows to overide autodetect by LANG environment' do
-    allow(R18n::I18n).to receive(:system_locale) { 'ru' }
-    ENV['LANG'] = 'en'
-    R18n.from_env
-    expect(r18n.locale).to eq R18n.locale('en')
+    it 'allows to overide autodetect by LANG environment' do
+      allow(R18n::I18n).to receive(:system_locale) { 'ru' }
+      ENV['LANG'] = 'en'
+      R18n.from_env
+      expect(r18n.locale).to eq R18n.locale('en')
+    end
+
+    it 'works with following `R18n.set`' do
+      R18n.from_env 'spec/i18n/'
+      R18n.set 'en'
+      expect(t.account.balance).to eq 'Balance for account'
+    end
   end
 end


### PR DESCRIPTION
The specific for `r18n-desktop` method `R18n.from_env` didn't use (set) `R18n.default_places`, which used by other adapters (`sinatra-r18n`, for example).

Resolve #151 

@bodrovis, can you please check?