### PR TITLE
Redefine `Translation#itself` method as key

### DIFF
--- a/r18n-core/lib/r18n-core/translation.rb
+++ b/r18n-core/lib/r18n-core/translation.rb
@@ -171,5 +171,11 @@ module R18n
     def dig(*keys)
       keys.reduce(self) { |result, key| result[key] }
     end
+
+    # I think we don't need in the Ruby core method,
+    # but it can be handy as a key
+    def itself
+      self[__method__]
+    end
   end
 end

--- a/r18n-core/spec/translation_spec.rb
+++ b/r18n-core/spec/translation_spec.rb
@@ -161,4 +161,11 @@ describe R18n::Translation do
       it { is_expected.not_to be_translated }
     end
   end
+
+  context '`itself` key' do
+    subject { R18n::I18n.new('en', DIR).page.itself.not_found }
+
+    it { is_expected.to be_translated }
+    it { is_expected.to eq 'Not found' }
+  end
 end

--- a/r18n-core/spec/translations/general/en.yml
+++ b/r18n-core/spec/translations/general/en.yml
@@ -45,3 +45,8 @@ echo2: Value2 is {{value}}
 boolean:
   true: Boolean is true
   false: Boolean is false
+
+page:
+  header: Title
+  itself:
+    not_found: Not found


### PR DESCRIPTION
I think we don't need for `Kernel#itself` implementation.

If you don't agree — please, open an issue or create a PR.