### PR TITLE
Fix warning about `BigDecimal` initialization

### DIFF
--- a/r18n-core/spec/locale_spec.rb
+++ b/r18n-core/spec/locale_spec.rb
@@ -74,7 +74,7 @@ describe R18n::Locale do
 
   it 'formats float in local traditions' do
     expect(@en.localize(-12_345.67)).to eq('−12,345.67')
-    expect(@en.localize(BigDecimal.new('-12345.67'))).to eq('−12,345.67')
+    expect(@en.localize(BigDecimal('-12345.67'))).to eq('−12,345.67')
   end
 
   it 'translates month, week days and am/pm names in strftime' do


### PR DESCRIPTION
https://docs.ruby-lang.org/en/2.5.0/NEWS.html#label-Stdlib+updates+-28outstanding+ones+only-29