### PR TITLE
Replace blank-padded day in date with no-padded

### DIFF
--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -118,7 +118,7 @@ module R18n
         time_am:     'AM',
         time_pm:     'PM',
         time_format: '_ %H:%M',
-        full_format: '%e %B',
+        full_format: '%-d %B',
         year_format: '_ %Y'
 
     def month_standalone

--- a/r18n-core/locales/af.rb
+++ b/r18n-core/locales/af.rb
@@ -20,7 +20,7 @@ module R18n
         time_pm:     "'s namiddag",
 
         date_format: '%d/%m/%Y',
-        full_format: '%e %B',
+        full_format: '%-d %B',
         year_format: '_, %Y',
         time_format: '_, %H:%M',
 

--- a/r18n-core/locales/cs.rb
+++ b/r18n-core/locales/cs.rb
@@ -19,8 +19,8 @@ module R18n
 
         time_am:     'dop.',
         time_pm:     'odp.',
-        date_format: '%e. %m. %Y',
-        full_format: '%e. %B',
+        date_format: '%-d. %m. %Y',
+        full_format: '%-d. %B',
 
         number_decimal: ',',
         number_group:   ' '

--- a/r18n-core/locales/de.rb
+++ b/r18n-core/locales/de.rb
@@ -19,7 +19,7 @@ module R18n
         time_am:     'vormittags',
         time_pm:     'nachmittags',
         date_format: '%d.%m.%Y',
-        full_format: '%e. %B',
+        full_format: '%-d. %B',
 
         number_decimal: ',',
         number_group:   '.'

--- a/r18n-core/locales/en-us.rb
+++ b/r18n-core/locales/en-us.rb
@@ -12,7 +12,7 @@ module R18n
 
         time_format: '_ %I:%M %p',
         date_format: '%m/%d/%Y',
-        full_format: '%B %e'
+        full_format: '%B %-d'
       )
     end
   end

--- a/r18n-core/locales/en.rb
+++ b/r18n-core/locales/en.rb
@@ -18,7 +18,7 @@ module R18n
         month_abbrs: %w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec],
 
         date_format: '%Y-%m-%d',
-        full_format: '%e of %B',
+        full_format: '%-d of %B',
         year_format: '_, %Y',
 
         number_decimal: '.',
@@ -41,7 +41,7 @@ module R18n
       def format_date_full(date, year = true, *_params)
         format = full_format
         format = year_format.sub('_', format) if year
-        strftime(date, format.sub('%e', ordinalize(date.mday)))
+        strftime(date, format.sub('%-d', ordinalize(date.mday)))
       end
     end
   end

--- a/r18n-core/locales/eo.rb
+++ b/r18n-core/locales/eo.rb
@@ -15,7 +15,7 @@ module R18n
         month_abbrs: %w[jan feb mar apr maj jun jul aŭg sep okt nov dec],
 
         date_format: '%Y-%m-%d',
-        full_format: 'la %e-a de %B',
+        full_format: 'la %-d-a de %B',
         year_format: '_ de %Y',
 
         number_decimal: '.',

--- a/r18n-core/locales/fa.rb
+++ b/r18n-core/locales/fa.rb
@@ -20,7 +20,7 @@ module R18n
         ],
 
         date_format: '%Y/%m/%d',
-        full_format: '%e %B',
+        full_format: '%-d %B',
         year_format: '_ %Y',
 
         number_decimal: '٫',

--- a/r18n-core/locales/fi.rb
+++ b/r18n-core/locales/fi.rb
@@ -20,7 +20,7 @@ module R18n
                              marraskuu joulukuu],
 
         date_format: '%d.%m.%Y',
-        full_format: '%e. %B',
+        full_format: '%-d. %B',
         time_format: '_ %H.%M',
 
         number_decimal: ',',

--- a/r18n-core/locales/fr.rb
+++ b/r18n-core/locales/fr.rb
@@ -24,8 +24,8 @@ module R18n
 
       def format_date_full(date, year = true, *_params)
         full = super(date, year)
-        if full[0..1] == ' 1'
-          '1er' + full[2..-1]
+        if full[0..1] == '1 '
+          '1er' + full[1..-1]
         else
           full
         end

--- a/r18n-core/locales/hr.rb
+++ b/r18n-core/locales/hr.rb
@@ -17,7 +17,7 @@ module R18n
         month_abbrs: %w[Sij Velj Ožu Tra Svi Lip Srp Kol Ruj Lis Stu Pro],
 
         date_format: '%d.%m.%Y',
-        full_format: '%e. %B',
+        full_format: '%-d. %B',
 
         number_decimal: ',',
         number_group:   '.'

--- a/r18n-core/locales/hu.rb
+++ b/r18n-core/locales/hu.rb
@@ -16,7 +16,7 @@ module R18n
         month_abbrs: %w[jan feb már ápr máj jún júl aug sze okt nov dec],
 
         date_format: '%Y. %m. %d.',
-        full_format: '%B %e.',
+        full_format: '%B %-d.',
         year_format: '%Y. _',
         time_format: '_, %H:%M',
 

--- a/r18n-core/locales/it.rb
+++ b/r18n-core/locales/it.rb
@@ -23,8 +23,8 @@ module R18n
 
       def format_date_full(date, year = true, *_params)
         full = super(date, year)
-        if full[0..1] == ' 1'
-          '1º' + full[2..-1]
+        if full[0..1] == '1 '
+          '1º' + full[1..-1]
         else
           full
         end

--- a/r18n-core/locales/kk.rb
+++ b/r18n-core/locales/kk.rb
@@ -20,7 +20,7 @@ module R18n
         time_am:     ' ертеңің',
         time_pm:     ' кештің',
         date_format: '%Y-%m-%d',
-        full_format: '%B %e-і',
+        full_format: '%B %-d-і',
         year_format: '%Y жылы _',
 
         number_decimal: ',',

--- a/r18n-core/locales/lv.rb
+++ b/r18n-core/locales/lv.rb
@@ -20,7 +20,7 @@ module R18n
                              decembris],
 
         date_format: '%d.%m.%Y.',
-        full_format: '%e.%B',
+        full_format: '%-d.%B',
         year_format: '%Y.gada _',
 
         number_decimal: ',',

--- a/r18n-core/locales/nb.rb
+++ b/r18n-core/locales/nb.rb
@@ -17,7 +17,7 @@ module R18n
         month_abbrs: %w[jan feb mar apr mai jun jul aug sep okt nov des],
 
         date_format: '%d.%m.%Y',
-        full_format: '%e. %B %Y',
+        full_format: '%-d. %B %Y',
 
         number_decimal: ',',
         number_group:   ' '

--- a/r18n-core/locales/nl.rb
+++ b/r18n-core/locales/nl.rb
@@ -18,7 +18,7 @@ module R18n
         time_am:     "'s ochtends",
         time_pm:     "'s middags",
         date_format: '%d-%m-%Y',
-        full_format: '%e %B',
+        full_format: '%-d %B',
 
         number_decimal: ',',
         number_group:   '.'

--- a/r18n-core/locales/sk.rb
+++ b/r18n-core/locales/sk.rb
@@ -20,7 +20,7 @@ module R18n
         time_am: 'dop.',
         time_pm: 'odp.',
         date_format: '%d.%m.%Y',
-        full_format: '%e. %B',
+        full_format: '%-d. %B',
 
         number_decimal: ',',
         number_group:   ' '

--- a/r18n-core/locales/sr-latn.rb
+++ b/r18n-core/locales/sr-latn.rb
@@ -16,7 +16,7 @@ module R18n
           month_abbrs: %w[jan feb mar apr maj jun jul avg sep okt nov dec],
 
           date_format: '%d.%m.%Y',
-          full_format: '%e. %B',
+          full_format: '%-d. %B',
 
           number_decimal: ',',
           number_group:   '.'

--- a/r18n-core/locales/sv-se.rb
+++ b/r18n-core/locales/sv-se.rb
@@ -16,7 +16,7 @@ module R18n
         month_abbrs: %w[jan feb mar apr maj jun jul aug okt nov dec],
 
         date_format: '%Y-%m-%d',
-        full_format: '%e %B %Y',
+        full_format: '%-d %B %Y',
 
         number_decimal: ',',
         number_group:   '.'

--- a/r18n-core/locales/th.rb
+++ b/r18n-core/locales/th.rb
@@ -17,7 +17,7 @@ module R18n
                         พ.ย. ธ.ค.],
 
         date_format: '%d/%m/%Y',
-        full_format: '%e %B',
+        full_format: '%-d %B',
         year_format: '_, %Y',
 
         number_decimal: '.',

--- a/r18n-core/locales/tr.rb
+++ b/r18n-core/locales/tr.rb
@@ -15,7 +15,7 @@ module R18n
         month_abbrs: %w[Oca Şub Mar Nis May Haz Tem Ağu Eyl Eki Kas Ara],
 
         date_format: '%d.%m.%Y',
-        full_format: '%B %e.',
+        full_format: '%B %-d.',
         year_format: '%Y. _',
         time_format: '_%H:%M',
 

--- a/r18n-core/locales/vi.rb
+++ b/r18n-core/locales/vi.rb
@@ -17,7 +17,7 @@ module R18n
         month_abbrs: %w[th1 th2 th3 th4 th5 th6 th7 th8 th9 th10 th11 th12],
 
         date_format: '%d/%m/%Y',
-        full_format: 'ngày %e %B',
+        full_format: 'ngày %-d %B',
         year_format: '_ năm %Y',
         time_format: '%H:%M, _',
 

--- a/r18n-core/spec/i18n_spec.rb
+++ b/r18n-core/spec/i18n_spec.rb
@@ -240,7 +240,7 @@ describe R18n::I18n do
     expect(i18n.l(time, '%A')).to      eq('Четверг')
     expect(i18n.l(time, :month)).to    eq('Январь')
     expect(i18n.l(time, :standard)).to eq('01.01.1970 00:00')
-    expect(i18n.l(time, :full)).to     eq(' 1 января 1970 00:00')
+    expect(i18n.l(time, :full)).to     eq('1 января 1970 00:00')
 
     expect(i18n.l(Date.new(0))).to eq('01.01.0000')
   end

--- a/r18n-core/spec/locales/fr_spec.rb
+++ b/r18n-core/spec/locales/fr_spec.rb
@@ -4,6 +4,6 @@ describe R18n::Locales::Fr do
   it 'formats French date' do
     fr = R18n::I18n.new('fr')
     expect(fr.l(Date.parse('2009-07-01'), :full)).to eq('1er juillet 2009')
-    expect(fr.l(Date.parse('2009-07-02'), :full)).to eq(' 2 juillet 2009')
+    expect(fr.l(Date.parse('2009-07-02'), :full)).to eq('2 juillet 2009')
   end
 end

--- a/r18n-core/spec/locales/hu_spec.rb
+++ b/r18n-core/spec/locales/hu_spec.rb
@@ -12,6 +12,6 @@ describe R18n::Locales::Hu do
   it 'uses Hungarian time format' do
     hu = R18n::I18n.new('hu')
     expect(hu.l(Time.at(0).utc)).to        eq('1970. 01. 01., 00:00')
-    expect(hu.l(Time.at(0).utc, :full)).to eq('1970. január  1., 00:00')
+    expect(hu.l(Time.at(0).utc, :full)).to eq('1970. január 1., 00:00')
   end
 end

--- a/r18n-core/spec/locales/it_spec.rb
+++ b/r18n-core/spec/locales/it_spec.rb
@@ -4,7 +4,7 @@ describe R18n::Locales::It do
   it 'formats Italian date' do
     italian = R18n::I18n.new('it')
     expect(italian.l(Date.parse('2009-07-01'), :full)).to eq('1º luglio 2009')
-    expect(italian.l(Date.parse('2009-07-02'), :full)).to eq(' 2 luglio 2009')
+    expect(italian.l(Date.parse('2009-07-02'), :full)).to eq('2 luglio 2009')
     expect(italian.l(Date.parse('2009-07-12'), :full)).to eq('12 luglio 2009')
   end
 end


### PR DESCRIPTION
I think space at the begin is unnecessary, and sometimes it even becomes double-space in the middle.