### PR TITLE
Fix `TranslatedString#to_ary`, don't return Untranslated

### DIFF
--- a/r18n-core/lib/r18n-core/translated_string.rb
+++ b/r18n-core/lib/r18n-core/translated_string.rb
@@ -82,8 +82,13 @@ module R18n
       Untranslated.new(translated, key, @locale, @filters)
     end
 
+    METHODS_FROM_STRING = %i[html_safe to_ary].freeze
+
+    private_constant :METHODS_FROM_STRING
+
     # Return untranslated, when user try to go deeper in translation.
     def method_missing(name, *_params)
+      return super if METHODS_FROM_STRING.include?(name)
       get_untranslated(name.to_s)
     end
   end

--- a/r18n-core/spec/translation_spec.rb
+++ b/r18n-core/spec/translation_spec.rb
@@ -168,4 +168,9 @@ describe R18n::Translation do
     it { is_expected.to be_translated }
     it { is_expected.to eq 'Not found' }
   end
+
+  it 'handles #to_ary' do
+    i18n = R18n::I18n.new('en', DIR)
+    expect([i18n.one, i18n.two].flatten).to eq [i18n.one, i18n.two]
+  end
 end


### PR DESCRIPTION
Especially for RSpec.