### PR TITLE
Remove duplicating `reposnd_to? :html_safe` in `TranslatedString`

### DIFF
--- a/r18n-core/lib/r18n-core/translated_string.rb
+++ b/r18n-core/lib/r18n-core/translated_string.rb
@@ -52,7 +52,7 @@ module R18n
 
     # Override to_s to make string html safe if `html_safe` method is defined.
     def to_s
-      if respond_to? :html_safe
+      if html_safe?
         super.html_safe
       else
         String.new(super)


### PR DESCRIPTION
Reuse `#html_safe?` method.